### PR TITLE
Backward incompatibility fix according to php 7.1 file_get_contents changes (negative offset)

### DIFF
--- a/common/lib/vendor/yiisoft/yii/framework/caching/CFileCache.php
+++ b/common/lib/vendor/yiisoft/yii/framework/caching/CFileCache.php
@@ -113,7 +113,7 @@ class CFileCache extends CCache
 	{
 		$cacheFile=$this->getCacheFile($key);
 		if(($time=$this->filemtime($cacheFile))>time())
-			return @file_get_contents($cacheFile,false,null,$this->embedExpiry ? 10 : -1);
+			return @file_get_contents($cacheFile,false,null,$this->embedExpiry ? 10 : 0);
 		elseif($time>0)
 			@unlink($cacheFile);
 		return false;


### PR DESCRIPTION
file_get_contents with offset -1 returns "}" always for cache files, should be 0 if we want to get all the file content.